### PR TITLE
Clean up README: remove TODO notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # 💿 Premiere Ecoute
 
-> TODO: Automatic update on show_live, issue with :url and "url" keys
-
 ![Banner](https://images.unsplash.com/photo-1727797216812-a0478ec92b64?ixlib=rb-4.1.0&q=85&fm=jpg&crop=center&cs=srgb&w=1200&h=300&fit=crop)
 
 > Select, listen and note new album releases with your Twitch community on [**https://premiere-ecoute.fly.dev/**](https://premiere-ecoute.fly.dev/)


### PR DESCRIPTION
Removed technical TODO about show_live update issue to keep README focused on user-facing documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)