### PR TITLE
Add versioned deployment information to footer

### DIFF
--- a/lib/premiere_ecoute.ex
+++ b/lib/premiere_ecoute.ex
@@ -18,8 +18,7 @@ defmodule PremiereEcoute do
       PubSub,
       Presence,
       Repo,
-      DataCase,
-      Version
+      DataCase
     ]
 
   alias PremiereEcoute.Events.Store

--- a/lib/premiere_ecoute_web/layouts/layouts.ex
+++ b/lib/premiere_ecoute_web/layouts/layouts.ex
@@ -40,7 +40,7 @@ defmodule PremiereEcouteWeb.Layouts do
     ~H"""
     <div class={"min-h-screen bg-gray-900 flex flex-col #{if @show_modal, do: "blur-sm", else: ""}"}>
       <.app_header current_user={(@current_scope && Map.get(@current_scope, :user)) || nil} current_scope={@current_scope} />
-
+      
     <!-- Spotify connection notification for streamers -->
       <%= if @current_scope && Map.get(@current_scope, :user) && Map.get(@current_scope, :user).role in [:streamer, :admin] && needs_spotify_connection?(Map.get(@current_scope, :user)) do %>
         <div class="bg-green-600 px-6 py-2">
@@ -62,7 +62,7 @@ defmodule PremiereEcouteWeb.Layouts do
           </div>
         </div>
       <% end %>
-
+      
     <!-- Layout with left sidebar for authenticated users -->
       <div class="flex flex-1">
         <.left_sidebar
@@ -70,13 +70,13 @@ defmodule PremiereEcouteWeb.Layouts do
           current_scope={@current_scope}
           current_page={@current_page}
         />
-
+        
     <!-- Main content area -->
         <main class="flex-1">
           {render_slot(@inner_block)}
         </main>
       </div>
-
+      
     <!-- Footer - spans full width under both sidebar and content -->
       <footer class="py-4 px-6 mt-auto" style="border-top: 1px solid var(--color-dark-800); background-color: var(--color-dark-900);">
         <div class="max-w-5xl mx-auto text-center">

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -289,8 +289,8 @@ msgstr ""
 msgid "Progress:"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:178
-#: lib/premiere_ecoute_web/layouts/layouts.ex:190
+#: lib/premiere_ecoute_web/layouts/layouts.ex:182
+#: lib/premiere_ecoute_web/layouts/layouts.ex:194
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -306,12 +306,12 @@ msgstr ""
 msgid "My Sessions"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:185
+#: lib/premiere_ecoute_web/layouts/layouts.ex:189
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:173
+#: lib/premiere_ecoute_web/layouts/layouts.ex:177
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -676,27 +676,27 @@ msgid "Bot"
 msgstr ""
 
 #: lib/premiere_ecoute_web/controllers/static/changelog/html/entry.html.heex:3
-#: lib/premiere_ecoute_web/layouts/layouts.ex:89
+#: lib/premiere_ecoute_web/layouts/layouts.ex:93
 #, elixir-autogen, elixir-format
 msgid "Changelog"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:121
+#: lib/premiere_ecoute_web/layouts/layouts.ex:125
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:105
+#: lib/premiere_ecoute_web/layouts/layouts.ex:109
 #, elixir-autogen, elixir-format
 msgid "Cookies"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:97
+#: lib/premiere_ecoute_web/layouts/layouts.ex:101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:113
+#: lib/premiere_ecoute_web/layouts/layouts.ex:117
 #, elixir-autogen, elixir-format
 msgid "Terms"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -290,8 +290,8 @@ msgstr ""
 msgid "Progress:"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:178
-#: lib/premiere_ecoute_web/layouts/layouts.ex:190
+#: lib/premiere_ecoute_web/layouts/layouts.ex:182
+#: lib/premiere_ecoute_web/layouts/layouts.ex:194
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
@@ -307,12 +307,12 @@ msgstr ""
 msgid "My Sessions"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:185
+#: lib/premiere_ecoute_web/layouts/layouts.ex:189
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:173
+#: lib/premiere_ecoute_web/layouts/layouts.ex:177
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
@@ -677,27 +677,27 @@ msgid "Bot"
 msgstr ""
 
 #: lib/premiere_ecoute_web/controllers/static/changelog/html/entry.html.heex:3
-#: lib/premiere_ecoute_web/layouts/layouts.ex:89
+#: lib/premiere_ecoute_web/layouts/layouts.ex:93
 #, elixir-autogen, elixir-format
 msgid "Changelog"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:121
+#: lib/premiere_ecoute_web/layouts/layouts.ex:125
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:105
+#: lib/premiere_ecoute_web/layouts/layouts.ex:109
 #, elixir-autogen, elixir-format
 msgid "Cookies"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:97
+#: lib/premiere_ecoute_web/layouts/layouts.ex:101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr ""
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:113
+#: lib/premiere_ecoute_web/layouts/layouts.ex:117
 #, elixir-autogen, elixir-format
 msgid "Terms"
 msgstr ""

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -290,8 +290,8 @@ msgstr "Précédent"
 msgid "Progress:"
 msgstr "Progression :"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:178
-#: lib/premiere_ecoute_web/layouts/layouts.ex:190
+#: lib/premiere_ecoute_web/layouts/layouts.ex:182
+#: lib/premiere_ecoute_web/layouts/layouts.ex:194
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Tentative de reconnexion"
@@ -307,12 +307,12 @@ msgstr "Se Déconnecter"
 msgid "My Sessions"
 msgstr "Mes Sessions"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:185
+#: lib/premiere_ecoute_web/layouts/layouts.ex:189
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Quelque chose s'est mal passé !"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:173
+#: lib/premiere_ecoute_web/layouts/layouts.ex:177
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Nous ne trouvons pas Internet"
@@ -677,27 +677,27 @@ msgid "Bot"
 msgstr "Bot"
 
 #: lib/premiere_ecoute_web/controllers/static/changelog/html/entry.html.heex:3
-#: lib/premiere_ecoute_web/layouts/layouts.ex:89
+#: lib/premiere_ecoute_web/layouts/layouts.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Changelog"
 msgstr "Nouveautés"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:121
+#: lib/premiere_ecoute_web/layouts/layouts.ex:125
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contact"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:105
+#: lib/premiere_ecoute_web/layouts/layouts.ex:109
 #, elixir-autogen, elixir-format
 msgid "Cookies"
 msgstr "Politique de cookies"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:97
+#: lib/premiere_ecoute_web/layouts/layouts.ex:101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Politique de confidentialité"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:113
+#: lib/premiere_ecoute_web/layouts/layouts.ex:117
 #, elixir-autogen, elixir-format
 msgid "Terms"
 msgstr "Conditions générales"

--- a/priv/gettext/it/LC_MESSAGES/default.po
+++ b/priv/gettext/it/LC_MESSAGES/default.po
@@ -290,8 +290,8 @@ msgstr "Precedente"
 msgid "Progress:"
 msgstr "Progresso:"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:178
-#: lib/premiere_ecoute_web/layouts/layouts.ex:190
+#: lib/premiere_ecoute_web/layouts/layouts.ex:182
+#: lib/premiere_ecoute_web/layouts/layouts.ex:194
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Tentativo di riconnessione"
@@ -307,12 +307,12 @@ msgstr "Disconnetti"
 msgid "My Sessions"
 msgstr "Le Mie Sessioni"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:185
+#: lib/premiere_ecoute_web/layouts/layouts.ex:189
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Qualcosa è andato storto!"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:173
+#: lib/premiere_ecoute_web/layouts/layouts.ex:177
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Non riusciamo a trovare internet"
@@ -677,27 +677,27 @@ msgid "Bot"
 msgstr "Bot"
 
 #: lib/premiere_ecoute_web/controllers/static/changelog/html/entry.html.heex:3
-#: lib/premiere_ecoute_web/layouts/layouts.ex:89
+#: lib/premiere_ecoute_web/layouts/layouts.ex:93
 #, elixir-autogen, elixir-format
 msgid "Changelog"
 msgstr "Registro delle Modifiche"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:121
+#: lib/premiere_ecoute_web/layouts/layouts.ex:125
 #, elixir-autogen, elixir-format
 msgid "Contact"
 msgstr "Contatti"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:105
+#: lib/premiere_ecoute_web/layouts/layouts.ex:109
 #, elixir-autogen, elixir-format
 msgid "Cookies"
 msgstr "Cookie"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:97
+#: lib/premiere_ecoute_web/layouts/layouts.ex:101
 #, elixir-autogen, elixir-format
 msgid "Privacy"
 msgstr "Privacy"
 
-#: lib/premiere_ecoute_web/layouts/layouts.ex:113
+#: lib/premiere_ecoute_web/layouts/layouts.ex:117
 #, elixir-autogen, elixir-format
 msgid "Terms"
 msgstr "Termini"


### PR DESCRIPTION
Create compile-time Version module that extracts application version from mix.exs and git commit hash. Display version information on the left side of the footer, with format "Version 1.0.0-abc1234".

🤖 Generated with [Claude Code](https://claude.com/claude-code)