### PR TITLE
Remove automatic poll event publishing in webhook handler

### DIFF
--- a/lib/premiere_ecoute_web/controllers/webhooks/twitch_controller.ex
+++ b/lib/premiere_ecoute_web/controllers/webhooks/twitch_controller.ex
@@ -36,7 +36,7 @@ defmodule PremiereEcouteWeb.Webhooks.TwitchController do
         case handle(conn.body_params) do
           %SendChatCommand{} = command -> PremiereEcoute.apply(command)
           %MessageSent{} = event -> Sessions.publish_message(event)
-          event -> Sessions.publish_poll(event)
+          _ -> :ok
         end
 
         send_resp(conn, 202, "")


### PR DESCRIPTION
The webhook handler no longer attempts to publish unhandled events as polls, preventing unintended behavior when receiving unexpected event types.

## Bugs

- Fix webhook handler publishing unknown events as polls