### PR TITLE
Route back navigation based on user role in session pages

### DIFF
--- a/lib/premiere_ecoute_web/live/sessions/session_live.html.heex
+++ b/lib/premiere_ecoute_web/live/sessions/session_live.html.heex
@@ -37,10 +37,11 @@
           <%!-- Left column --%>
           <div class="w-64 shrink-0 space-y-6">
             <%!-- Back link --%>
+            <% back_path = if assigns[:current_scope] && assigns[:current_scope].user && assigns[:current_scope].user.role in [:streamer, :bot, :admin], do: ~p"/sessions/retrospective", else: ~p"/sessions/retrospective/tops" %>
             <.link
               id="back-link"
               phx-hook="BackLink"
-              navigate={~p"/sessions/retrospective"}
+              navigate={back_path}
               class="inline-flex items-center gap-1.5 ml-6 px-2.5 py-1.5 rounded-md bg-purple-600/50 hover:bg-purple-600/70 border border-purple-400/60 text-white text-xs font-medium"
             >
               <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -827,8 +828,9 @@
     <% else %>
       <div class="max-w-6xl mx-auto px-6 py-20 text-center">
         <p class="text-slate-400 mb-4">{gettext("Session not found")}</p>
+        <% back_path_404 = if assigns[:current_scope] && assigns[:current_scope].user && assigns[:current_scope].user.role in [:streamer, :bot, :admin], do: ~p"/sessions/retrospective", else: ~p"/sessions/retrospective/tops" %>
         <.link
-          navigate={~p"/sessions/retrospective"}
+          navigate={back_path_404}
           class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-700 text-sm"
         >
           {gettext("Back to history")}


### PR DESCRIPTION
## Summary
Updated the session live view to conditionally route users back to different pages based on their role when navigating from the session details page.

## Key Changes
- Added role-based navigation logic for the back link on the session details page
  - Streamer, bot, and admin users are routed to `/sessions/retrospective`
  - Other users are routed to `/sessions/retrospective/tops`
- Applied the same conditional routing to the 404 "Session not found" error page back link
- Both back links now check `current_scope.user.role` to determine the appropriate destination

## Implementation Details
The navigation path is determined by evaluating the user's role at render time:
```elixir
back_path = if assigns[:current_scope] && assigns[:current_scope].user && assigns[:current_scope].user.role in [:streamer, :bot, :admin], do: ~p"/sessions/retrospective", else: ~p"/sessions/retrospective/tops"
```

This ensures users are directed to the appropriate retrospective view based on their permissions and role.

https://claude.ai/code/session_01NUpGMgCt8eG7PY4Psx8jWP