### PR TITLE
Add explicit content flag support to albums and tracks

### DIFF
--- a/lib/premiere_ecoute/apis/music_provider/spotify_api/albums.ex
+++ b/lib/premiere_ecoute/apis/music_provider/spotify_api/albums.ex
@@ -31,6 +31,17 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.Albums do
   """
   @spec parse_album_with_tracks(map()) :: Album.t()
   def parse_album_with_tracks(data) do
+    tracks =
+      Enum.map(data["tracks"]["items"], fn track ->
+        %Track{
+          provider_ids: %{spotify: track["id"]},
+          name: track["name"],
+          track_number: track["track_number"] || 0,
+          duration_ms: track["duration_ms"] || 0,
+          explicit: track["explicit"] || false
+        }
+      end)
+
     %Album{
       provider_ids: %{spotify: data["id"]},
       name: data["name"],
@@ -38,15 +49,8 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.Albums do
       release_date: Parser.parse_release_date(data["release_date"]),
       cover_url: Parser.parse_album_cover_url(data["images"]),
       total_tracks: data["total_tracks"],
-      tracks:
-        Enum.map(data["tracks"]["items"], fn track ->
-          %Track{
-            provider_ids: %{spotify: track["id"]},
-            name: track["name"],
-            track_number: track["track_number"] || 0,
-            duration_ms: track["duration_ms"] || 0
-          }
-        end)
+      explicit: Enum.any?(tracks, & &1.explicit),
+      tracks: tracks
     }
   end
 end

--- a/lib/premiere_ecoute/discography/album.ex
+++ b/lib/premiere_ecoute/discography/album.ex
@@ -34,6 +34,7 @@ defmodule PremiereEcoute.Discography.Album do
           release_date: Date.t() | nil,
           cover_url: String.t() | nil,
           total_tracks: integer() | nil,
+          explicit: boolean() | nil,
           tracks: entity([Track.t()]),
           artists: entity([Artist.t()]),
           inserted_at: DateTime.t() | nil,
@@ -49,6 +50,8 @@ defmodule PremiereEcoute.Discography.Album do
     field :cover_url, :string
     field :total_tracks, :integer
     field :artist, :string, virtual: true
+    # AIDEV-NOTE: virtual field derived from track-level explicit flags; not persisted (Spotify tracks carry explicit, album derives it)
+    field :explicit, :boolean, virtual: true, default: false
 
     has_many :tracks, Track, foreign_key: :album_id, on_delete: :delete_all
     many_to_many :artists, Artist, join_through: AlbumArtist, on_replace: :delete

--- a/lib/premiere_ecoute/discography/album/track.ex
+++ b/lib/premiere_ecoute/discography/album/track.ex
@@ -24,6 +24,7 @@ defmodule PremiereEcoute.Discography.Album.Track do
           name: String.t() | nil,
           track_number: integer() | nil,
           duration_ms: integer() | nil,
+          explicit: boolean() | nil,
           album_id: integer() | nil,
           album: entity(Album.t()),
           album_spotify_id: String.t() | nil,
@@ -41,6 +42,8 @@ defmodule PremiereEcoute.Discography.Album.Track do
     # TODO: must be rethink - how to carry metadata information (here spotify album id) ?
     # AIDEV-NOTE: virtual field used to carry album_spotify_id from Spotify API response without persisting it
     field :album_spotify_id, :string, virtual: true
+    # AIDEV-NOTE: virtual field populated from Spotify API response; not persisted
+    field :explicit, :boolean, virtual: true, default: false
 
     belongs_to :album, Album
 

--- a/lib/premiere_ecoute_web/live/sessions/components/session_selection_components.ex
+++ b/lib/premiere_ecoute_web/live/sessions/components/session_selection_components.ex
@@ -265,7 +265,12 @@ defmodule PremiereEcouteWeb.Sessions.Components.SessionSelectionComponents do
                   <% end %>
                 </div>
                 <div>
-                  <h3 class="text-2xl font-bold text-white mb-1">{@selected_album.result.name}</h3>
+                  <div class="flex items-center gap-2 mb-1">
+                    <h3 class="text-2xl font-bold text-white">{@selected_album.result.name}</h3>
+                    <%= if @selected_album.result.explicit do %>
+                      <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-bold bg-gray-500 text-white shrink-0">E</span>
+                    <% end %>
+                  </div>
                   <p class="text-white text-lg font-semibold mb-3">{@selected_album.result.artist}</p>
                   <div class="flex items-center space-x-6 text-white/90 text-sm">
                     <div class="flex items-center space-x-2">
@@ -320,8 +325,11 @@ defmodule PremiereEcouteWeb.Sessions.Components.SessionSelectionComponents do
                   <div class="rounded-lg p-3 hover:bg-white/5 transition-colors" style="background-color: rgba(0, 0, 0, 0.3);">
                     <div class="flex items-center space-x-3">
                       <span class="text-sm text-gray-300 w-6 text-right">{index + 1}</span>
-                      <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-1.5 flex-1 min-w-0">
                         <h5 class="font-medium text-white truncate text-sm">{track.name}</h5>
+                        <%= if Map.get(track, :explicit) do %>
+                          <span class="inline-flex items-center px-1 py-0.5 rounded text-xs font-bold bg-gray-500 text-white shrink-0">E</span>
+                        <% end %>
                       </div>
                       <span class="text-sm text-gray-300">{PremiereEcouteCore.Duration.timer(track.duration_ms)}</span>
                     </div>

--- a/test/premiere_ecoute/apis/music_provider/spotify_api/albums_test.exs
+++ b/test/premiere_ecoute/apis/music_provider/spotify_api/albums_test.exs
@@ -7,6 +7,7 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.AlbumsTest do
   alias PremiereEcoute.Apis.MusicProvider.SpotifyApi
   alias PremiereEcouteCore.Cache
 
+  alias PremiereEcoute.Apis.MusicProvider.SpotifyApi.Albums
   alias PremiereEcoute.Discography.Album
   alias PremiereEcoute.Discography.Album.Track
   alias PremiereEcoute.Discography.Artist
@@ -48,6 +49,7 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.AlbumsTest do
                release_date: ~D[2024-05-17],
                cover_url: "https://i.scdn.co/image/ab67616d00001e0271d62ea7ea8a5be92d3c1f62",
                total_tracks: 10,
+               explicit: false,
                tracks: [
                  %Track{
                    id: nil,
@@ -123,6 +125,34 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.AlbumsTest do
              } = album
     end
 
+    test "returns album marked as explicit when all tracks are explicit", %{token: token} do
+      ApiMock.expect(
+        SpotifyApi,
+        path: {:get, "/v1/albums/5K4W6rqBFWDnAN6FQUkS6x"},
+        headers: [
+          {"authorization", "Bearer #{token}"},
+          {"content-type", "application/json"}
+        ],
+        response: "spotify_api/albums/get_album/explicit_album.json",
+        status: 200
+      )
+
+      {:ok, album} = SpotifyApi.get_album("5K4W6rqBFWDnAN6FQUkS6x")
+
+      assert %Album{
+               provider_ids: %{spotify: "5K4W6rqBFWDnAN6FQUkS6x"},
+               name: "The Marshall Mathers LP (Explicit)",
+               artists: [%Artist{name: "Eminem"}],
+               total_tracks: 3,
+               explicit: true,
+               tracks: [
+                 %Track{name: "The Way I Am", track_number: 1, explicit: true},
+                 %Track{name: "Stan", track_number: 2, explicit: true},
+                 %Track{name: "Kim", track_number: 3, explicit: true}
+               ]
+             } = album
+    end
+
     test "returns an error from an unknown unique identifier", %{token: token} do
       ApiMock.expect(
         SpotifyApi,
@@ -143,6 +173,81 @@ defmodule PremiereEcoute.Apis.MusicProvider.SpotifyApi.AlbumsTest do
 
       assert logs =~
                "[error] Spotify API unexpected status: 404 - %{\"error\" => %{\"message\" => \"Resource not found\", \"status\" => 404}}"
+    end
+  end
+
+  describe "parse_album_with_tracks/1" do
+    defp spotify_response(tracks) do
+      %{
+        "id" => "abc123",
+        "name" => "Test Album",
+        "release_date" => "2024-01-01",
+        "release_date_precision" => "day",
+        "total_tracks" => length(tracks),
+        "images" => [],
+        "artists" => [%{"id" => "art1", "name" => "Test Artist", "type" => "artist"}],
+        "tracks" => %{"items" => tracks}
+      }
+    end
+
+    defp track(id, name, number, explicit) do
+      %{
+        "id" => id,
+        "name" => name,
+        "track_number" => number,
+        "duration_ms" => 200_000,
+        "explicit" => explicit
+      }
+    end
+
+    test "marks album as non-explicit when all tracks have explicit: false" do
+      data = spotify_response([
+        track("t1", "Clean Track One", 1, false),
+        track("t2", "Clean Track Two", 2, false)
+      ])
+
+      album = Albums.parse_album_with_tracks(data)
+
+      assert album.explicit == false
+      assert Enum.all?(album.tracks, &(&1.explicit == false))
+    end
+
+    test "marks album as explicit when all tracks are explicit" do
+      data = spotify_response([
+        track("t1", "Explicit Track One", 1, true),
+        track("t2", "Explicit Track Two", 2, true)
+      ])
+
+      album = Albums.parse_album_with_tracks(data)
+
+      assert album.explicit == true
+      assert Enum.all?(album.tracks, &(&1.explicit == true))
+    end
+
+    test "marks album as explicit when at least one track is explicit" do
+      data = spotify_response([
+        track("t1", "Clean Track", 1, false),
+        track("t2", "Explicit Track", 2, true),
+        track("t3", "Another Clean Track", 3, false)
+      ])
+
+      album = Albums.parse_album_with_tracks(data)
+
+      assert album.explicit == true
+      assert Enum.at(album.tracks, 0).explicit == false
+      assert Enum.at(album.tracks, 1).explicit == true
+      assert Enum.at(album.tracks, 2).explicit == false
+    end
+
+    test "treats missing explicit field in track response as non-explicit" do
+      data = spotify_response([
+        %{"id" => "t1", "name" => "Track", "track_number" => 1, "duration_ms" => 200_000}
+      ])
+
+      album = Albums.parse_album_with_tracks(data)
+
+      assert album.explicit == false
+      assert Enum.at(album.tracks, 0).explicit == false
     end
   end
 end

--- a/test/support/apis/spotify_api/albums/get_album/explicit_album.json
+++ b/test/support/apis/spotify_api/albums/get_album/explicit_album.json
@@ -1,0 +1,124 @@
+{
+  "album_type": "album",
+  "total_tracks": 3,
+  "id": "5K4W6rqBFWDnAN6FQUkS6x",
+  "name": "The Marshall Mathers LP (Explicit)",
+  "release_date": "2000-05-23",
+  "release_date_precision": "day",
+  "images": [
+    {
+      "url": "https://i.scdn.co/image/ab67616d0000b2739a1bb73de0a7c6a64df02f8a",
+      "height": 640,
+      "width": 640
+    },
+    {
+      "url": "https://i.scdn.co/image/ab67616d00001e029a1bb73de0a7c6a64df02f8a",
+      "height": 300,
+      "width": 300
+    },
+    {
+      "url": "https://i.scdn.co/image/ab67616d000048519a1bb73de0a7c6a64df02f8a",
+      "height": 64,
+      "width": 64
+    }
+  ],
+  "artists": [
+    {
+      "id": "7dGJo4pcD2V6oG8kP0tJRR",
+      "name": "Eminem",
+      "type": "artist",
+      "external_urls": {"spotify": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"},
+      "href": "https://api.spotify.com/v1/artists/7dGJo4pcD2V6oG8kP0tJRR",
+      "uri": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR"
+    }
+  ],
+  "tracks": {
+    "href": "https://api.spotify.com/v1/albums/5K4W6rqBFWDnAN6FQUkS6x/tracks?offset=0&limit=50",
+    "limit": 50,
+    "next": null,
+    "offset": 0,
+    "previous": null,
+    "total": 3,
+    "items": [
+      {
+        "id": "7GhIk7Il098yCjg4BQjzvb",
+        "name": "The Way I Am",
+        "track_number": 1,
+        "duration_ms": 290666,
+        "explicit": true,
+        "disc_number": 1,
+        "type": "track",
+        "uri": "spotify:track:7GhIk7Il098yCjg4BQjzvb",
+        "is_local": false,
+        "preview_url": null,
+        "external_urls": {"spotify": "https://open.spotify.com/track/7GhIk7Il098yCjg4BQjzvb"},
+        "href": "https://api.spotify.com/v1/tracks/7GhIk7Il098yCjg4BQjzvb",
+        "artists": [
+          {
+            "id": "7dGJo4pcD2V6oG8kP0tJRR",
+            "name": "Eminem",
+            "type": "artist",
+            "external_urls": {"spotify": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"},
+            "href": "https://api.spotify.com/v1/artists/7dGJo4pcD2V6oG8kP0tJRR",
+            "uri": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR"
+          }
+        ]
+      },
+      {
+        "id": "7lQ8MOoKJcH3E8KbxVzZah",
+        "name": "Stan",
+        "track_number": 2,
+        "duration_ms": 404893,
+        "explicit": true,
+        "disc_number": 1,
+        "type": "track",
+        "uri": "spotify:track:7lQ8MOoKJcH3E8KbxVzZah",
+        "is_local": false,
+        "preview_url": null,
+        "external_urls": {"spotify": "https://open.spotify.com/track/7lQ8MOoKJcH3E8KbxVzZah"},
+        "href": "https://api.spotify.com/v1/tracks/7lQ8MOoKJcH3E8KbxVzZah",
+        "artists": [
+          {
+            "id": "7dGJo4pcD2V6oG8kP0tJRR",
+            "name": "Eminem",
+            "type": "artist",
+            "external_urls": {"spotify": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"},
+            "href": "https://api.spotify.com/v1/artists/7dGJo4pcD2V6oG8kP0tJRR",
+            "uri": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR"
+          }
+        ]
+      },
+      {
+        "id": "3iVcZ5G6tvkXZkZKlMpIUs",
+        "name": "Kim",
+        "track_number": 3,
+        "duration_ms": 399533,
+        "explicit": true,
+        "disc_number": 1,
+        "type": "track",
+        "uri": "spotify:track:3iVcZ5G6tvkXZkZKlMpIUs",
+        "is_local": false,
+        "preview_url": null,
+        "external_urls": {"spotify": "https://open.spotify.com/track/3iVcZ5G6tvkXZkZKlMpIUs"},
+        "href": "https://api.spotify.com/v1/tracks/3iVcZ5G6tvkXZkZKlMpIUs",
+        "artists": [
+          {
+            "id": "7dGJo4pcD2V6oG8kP0tJRR",
+            "name": "Eminem",
+            "type": "artist",
+            "external_urls": {"spotify": "https://open.spotify.com/artist/7dGJo4pcD2V6oG8kP0tJRR"},
+            "href": "https://api.spotify.com/v1/artists/7dGJo4pcD2V6oG8kP0tJRR",
+            "uri": "spotify:artist:7dGJo4pcD2V6oG8kP0tJRR"
+          }
+        ]
+      }
+    ]
+  },
+  "copyrights": [
+    {"text": "© 2000 Aftermath Entertainment/Interscope Records", "type": "C"}
+  ],
+  "external_ids": {"upc": "00606949048327"},
+  "genres": ["hip hop", "rap"],
+  "label": "Aftermath/Interscope",
+  "popularity": 87
+}


### PR DESCRIPTION
## Summary
Add support for tracking explicit content flags at both the album and track levels. Albums now derive their explicit status from their tracks, and both are displayed in the UI with an "E" badge.

## Changes
- **Album model**: Added virtual `explicit` field that derives its value from track-level explicit flags
- **Track model**: Added virtual `explicit` field populated from Spotify API responses
- **Spotify API parser**: Extract `explicit` flag from track data and compute album-level explicit status by checking if any track is explicit
- **UI components**: Display explicit content badges ("E") next to album names and individual track names in the session selection interface

## Implementation Details
- Both `explicit` fields are virtual and not persisted to the database, as they come directly from Spotify API responses
- Album explicit status is computed at parse time using `Enum.any?()` to check if any track in the album is marked explicit
- UI badges use consistent styling (gray background, white text, small font) and are positioned inline with titles
- Added AIDEV-NOTE comments documenting the virtual field design decisions for future maintainers

https://claude.ai/code/session_01UQCRSRBETrUPSozv5B6fT1