### PR TITLE
feat: add post-session voting for viewers who missed the live stream

### DIFF
--- a/lib/premiere_ecoute/sessions.ex
+++ b/lib/premiere_ecoute/sessions.ex
@@ -56,6 +56,8 @@ defmodule PremiereEcoute.Sessions do
 
   defdelegate create_vote(vote), to: Scores.Vote, as: :create
   defdelegate get_track_votes_for_user(track_ids, viewer_id), to: Scores.Vote, as: :for_tracks_and_viewer
+  defdelegate post_vote_eligible?(session_id, viewer_id), to: Scores.PostSessionVote, as: :eligible?
+  defdelegate submit_post_votes(session, viewer_id, votes), to: Scores.PostSessionVote, as: :submit
 
   # Retrospective
   defdelegate get_albums_by_period(user, period, opts \\ %{}), to: Retrospective.History

--- a/lib/premiere_ecoute/sessions/scores/post_session_vote.ex
+++ b/lib/premiere_ecoute/sessions/scores/post_session_vote.ex
@@ -1,0 +1,66 @@
+defmodule PremiereEcoute.Sessions.Scores.PostSessionVote do
+  @moduledoc """
+  Post-session voting for viewers who missed the live session.
+
+  Allows viewers with zero votes in a stopped session to submit track votes
+  directly (bypassing the Broadway chat pipeline) and triggers a report refresh.
+  """
+
+  import Ecto.Query
+
+  alias PremiereEcoute.Repo
+  alias PremiereEcoute.Sessions.ListeningSession
+  alias PremiereEcoute.Sessions.Retrospective.Report
+  alias PremiereEcoute.Sessions.Scores.Vote
+
+  @doc """
+  Returns true when the viewer has cast zero votes in this session.
+
+  Eligibility is scoped to the session — viewers who voted on some tracks during
+  the live stream are not eligible.
+  """
+  @spec eligible?(integer(), String.t()) :: boolean()
+  def eligible?(session_id, viewer_id) do
+    from(v in Vote,
+      where: v.session_id == ^session_id and v.viewer_id == ^viewer_id,
+      select: count(v.id)
+    )
+    |> Repo.one()
+    |> Kernel.==(0)
+  end
+
+  @doc """
+  Inserts post-session votes and regenerates the session report.
+
+  Only accepts a stopped session and at least one vote. Existing votes for the
+  same (viewer, session, track) triple are silently ignored via on_conflict.
+  """
+  @spec submit(ListeningSession.t(), String.t(), %{integer() => String.t()}) ::
+          {:ok, Report.t()} | {:error, term()}
+  def submit(
+        %ListeningSession{id: session_id, status: :stopped} = session,
+        viewer_id,
+        votes_by_track_id
+      )
+      when is_binary(viewer_id) and map_size(votes_by_track_id) > 0 do
+    now = DateTime.truncate(DateTime.utc_now(), :second)
+
+    vote_entries =
+      Enum.map(votes_by_track_id, fn {track_id, value} ->
+        %{
+          viewer_id: viewer_id,
+          session_id: session_id,
+          track_id: track_id,
+          value: value,
+          is_streamer: false,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    Vote.create_all(vote_entries, on_conflict: :nothing)
+    Report.generate(session)
+  end
+
+  def submit(_session, _viewer_id, _votes), do: {:error, :invalid}
+end

--- a/lib/premiere_ecoute_web/live/sessions/session_live.ex
+++ b/lib/premiere_ecoute_web/live/sessions/session_live.ex
@@ -10,6 +10,7 @@ defmodule PremiereEcouteWeb.Sessions.SessionLive do
   use PremiereEcouteWeb, :live_view
 
   alias PremiereEcoute.Repo
+  alias PremiereEcoute.Sessions
   alias PremiereEcoute.Sessions.ListeningSession
   alias PremiereEcoute.Sessions.ListeningSession.Review
   alias PremiereEcoute.Sessions.Retrospective.Report
@@ -36,6 +37,16 @@ defmodule PremiereEcouteWeb.Sessions.SessionLive do
         do: ReviewLikes.liked_review_ids(review_ids, current_user.id),
         else: MapSet.new()
 
+    my_twitch_id =
+      current_user && current_user.twitch && current_user.twitch.user_id
+
+    # AIDEV-NOTE: post-vote eligibility — only for stopped sessions when viewer has 0 votes
+    post_vote_eligible =
+      listening_session.status == :stopped &&
+        is_binary(my_twitch_id) &&
+        listening_session.source in [:album, :playlist] &&
+        Sessions.post_vote_eligible?(listening_session.id, my_twitch_id)
+
     socket =
       socket
       |> assign(:listening_session, listening_session)
@@ -43,6 +54,10 @@ defmodule PremiereEcouteWeb.Sessions.SessionLive do
       |> assign(:tracks, tracks)
       |> assign(:reviews, reviews)
       |> assign(:liked_ids, liked_ids)
+      |> assign(:my_twitch_id, my_twitch_id)
+      |> assign(:post_vote_eligible, post_vote_eligible)
+      |> assign(:post_vote_modal_open, false)
+      |> assign(:post_vote_selections, %{})
       |> assign(:review_modal_open, false)
       |> assign(:review_form, nil)
       |> assign(:editing_review, nil)
@@ -55,6 +70,50 @@ defmodule PremiereEcouteWeb.Sessions.SessionLive do
   @impl true
   def handle_params(_params, _url, socket) do
     {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("open_post_vote_modal", _params, socket) do
+    {:noreply, assign(socket, :post_vote_modal_open, true)}
+  end
+
+  @impl true
+  def handle_event("close_post_vote_modal", _params, socket) do
+    {:noreply, socket |> assign(:post_vote_modal_open, false) |> assign(:post_vote_selections, %{})}
+  end
+
+  @impl true
+  def handle_event("set_post_vote", %{"track_id" => track_id, "value" => value}, socket) do
+    selections = Map.put(socket.assigns.post_vote_selections, String.to_integer(track_id), value)
+    {:noreply, assign(socket, :post_vote_selections, selections)}
+  end
+
+  @impl true
+  def handle_event("submit_post_votes", _params, socket) do
+    session = socket.assigns.listening_session
+    viewer_id = socket.assigns.my_twitch_id
+    selections = socket.assigns.post_vote_selections
+
+    if socket.assigns.post_vote_eligible && is_binary(viewer_id) && map_size(selections) > 0 do
+      case Sessions.submit_post_votes(session, viewer_id, selections) do
+        {:ok, report} ->
+          tracks = build_tracks(session, report)
+
+          {:noreply,
+           socket
+           |> assign(:report, report)
+           |> assign(:tracks, tracks)
+           |> assign(:post_vote_modal_open, false)
+           |> assign(:post_vote_selections, %{})
+           |> assign(:post_vote_eligible, false)
+           |> put_flash(:info, gettext("Your votes have been submitted!"))}
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, gettext("Failed to submit votes"))}
+      end
+    else
+      {:noreply, socket}
+    end
   end
 
   @impl true

--- a/lib/premiere_ecoute_web/live/sessions/session_live.html.heex
+++ b/lib/premiere_ecoute_web/live/sessions/session_live.html.heex
@@ -344,6 +344,22 @@
               </div>
             <% end %>
 
+            <%!-- Post-session vote prompt --%>
+            <%= if @post_vote_eligible do %>
+              <div class="mb-6 flex items-center justify-between px-4 py-3 rounded-xl bg-purple-900/20 border border-purple-500/30">
+                <div>
+                  <p class="text-sm font-medium text-purple-200">{gettext("You didn't vote during this session")}</p>
+                  <p class="text-xs text-slate-500 mt-0.5">{gettext("You can still rate the tracks you heard.")}</p>
+                </div>
+                <button
+                  phx-click="open_post_vote_modal"
+                  class="px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-500 text-white text-sm font-semibold transition-all shrink-0"
+                >
+                  {gettext("Cast your votes")}
+                </button>
+              </div>
+            <% end %>
+
             <%!-- Track list --%>
             <%= if @listening_session.source in [:album, :playlist] && @tracks != [] do %>
               <section>
@@ -822,6 +838,84 @@
                 </button>
               </div>
             </.form>
+          </div>
+        </div>
+      <% end %>
+
+      <%!-- Post-session voting modal --%>
+      <%= if @post_vote_modal_open do %>
+        <% vote_tracks =
+          case @listening_session.source do
+            :album -> Enum.sort_by(@listening_session.album.tracks, & &1.track_number)
+            :playlist -> @listening_session.playlist.tracks
+            _ -> []
+          end %>
+        <div class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm">
+          <div class="bg-gray-900 border border-purple-500/30 rounded-2xl p-8 w-full max-w-xl shadow-2xl max-h-[90vh] flex flex-col">
+            <div class="flex items-center justify-between mb-2 shrink-0">
+              <h3 class="text-xl font-bold text-white">{gettext("Cast your votes")}</h3>
+              <button phx-click="close_post_vote_modal" class="text-slate-500 hover:text-white transition-colors">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <p class="text-xs text-slate-500 mb-5 shrink-0">
+              {gettext("Rate each track you heard. You can skip tracks you didn't listen to.")}
+            </p>
+
+            <div class="overflow-y-auto flex-1 space-y-3 pr-1">
+              <%= for track <- vote_tracks do %>
+                <% selected = Map.get(@post_vote_selections, track.id) %>
+                <div class="flex items-center gap-3">
+                  <div class="flex items-center gap-2 min-w-0 flex-1">
+                    <%= if @listening_session.source == :album && track.track_number do %>
+                      <span class="text-slate-600 font-mono text-xs w-4 text-right shrink-0">
+                        {track.track_number}
+                      </span>
+                    <% end %>
+                    <p class="text-slate-300 text-sm truncate">{track.name}</p>
+                  </div>
+                  <div class="flex gap-1 shrink-0 flex-wrap justify-end">
+                    <%= for option <- (@listening_session.vote_options || []) do %>
+                      <button
+                        type="button"
+                        phx-click="set_post_vote"
+                        phx-value-track_id={track.id}
+                        phx-value-value={option}
+                        class={"px-2.5 py-1 rounded text-xs font-semibold transition-all border #{if selected == option, do: "bg-purple-600 border-purple-400 text-white", else: "bg-white/5 border-white/10 text-slate-400 hover:border-purple-400 hover:text-white"}"}
+                      >
+                        {option}
+                      </button>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+
+            <div class="flex gap-3 pt-5 shrink-0 border-t border-white/10 mt-4">
+              <% any_selected = map_size(@post_vote_selections) > 0 %>
+              <button
+                type="button"
+                phx-click="submit_post_votes"
+                disabled={!any_selected}
+                class={"flex-1 py-2.5 rounded-lg text-sm font-semibold transition-all #{if any_selected, do: "bg-purple-600 hover:bg-purple-500 text-white", else: "bg-purple-900/30 text-slate-600 cursor-not-allowed"}"}
+              >
+                {ngettext(
+                  "Submit %{count} vote",
+                  "Submit %{count} votes",
+                  map_size(@post_vote_selections),
+                  count: map_size(@post_vote_selections)
+                )}
+              </button>
+              <button
+                type="button"
+                phx-click="close_post_vote_modal"
+                class="flex-1 bg-white/10 hover:bg-white/20 text-white py-2.5 rounded-lg text-sm font-semibold transition-all"
+              >
+                {gettext("Cancel")}
+              </button>
+            </div>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
Viewers with zero votes in a stopped session can now open a modal on the
session page to rate each track individually. Votes are inserted directly
(bypassing the Broadway pipeline) and the session report is regenerated
immediately after submission.

Eligibility gate: stopped session + Twitch auth + zero prior votes.

https://claude.ai/code/session_0135jiMsbkoZB4wqNDPHhVLS